### PR TITLE
Revert xpath translation change to make it consistent

### DIFF
--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -403,7 +403,9 @@ class GenericTranslator(object):
 
     def xpath_relation_direct_adjacent_combinator(self, left, right):
         """right is a sibling immediately after left; select left"""
-        xpath = left.add_condition("following-sibling::{}[position() = 1]".format(right.element))
+        xpath = left.add_condition(
+            "following-sibling::*[(name() = '{}') and (position() = 1)]".format(right.element)
+        )
         return xpath
 
     def xpath_relation_indirect_adjacent_combinator(self, left, right):

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -516,7 +516,7 @@ class TestCssselect(unittest.TestCase):
         assert xpath("e:has(~ f)") == "e[following-sibling::f]"
         assert (
             xpath("e:has(+ f)")
-            == "e[following-sibling::f[position() = 1]]"
+            == "e[following-sibling::*[(name() = 'f') and (position() = 1)]]"
         )
         assert xpath('e f') == (
             "e/descendant-or-self::*/f")


### PR DESCRIPTION
This reverts [the change I suggested](https://github.com/scrapy/cssselect/pull/115#discussion_r673890181), I realized the new way is not consistent with [existing code](https://github.com/scrapy/cssselect/blob/v1.1.0/tests/test_cssselect.py#L500). Sorry for wasting your time!